### PR TITLE
small plotting and documentation changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: MMUPHin is an R package for meta-analysis tasks of microbiome
     d) meta-analysis unsupervised continuous structure discovery.
 License: MIT + file LICENSE
 Encoding: UTF-8
-RoxygenNote: 6.1.1
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr
 SystemRequirements:
     glpk (>= 4.57)

--- a/R/helpers_lm_meta.R
+++ b/R/helpers_lm_meta.R
@@ -356,8 +356,8 @@ rma_wrapper <- function(maaslin_fits,
         if(i_rma_fit$pval < 0.05 & !is.null(forest_plot))
           metafor::forest(
             i_rma_fit,
-            xlab = shorten_name(feature, cutoff = 5),
-            slab = shorten_name(lvl_batch[ind_features[feature, ]], cutoff = 3))
+            xlab = shorten_name(feature, cutoff = 15),
+            slab = shorten_name(lvl_batch[ind_features[feature, ]], cutoff = 5))
       }
       if(count_feature[feature] == 1) {
         i_ind_features <- ind_features[feature, ]

--- a/R/lm_meta.R
+++ b/R/lm_meta.R
@@ -25,7 +25,7 @@
 #' \item{transform}{
 #' character. \code{transform} parameter for Maaslin2. See 
 #' \code{\link[Maaslin2]{Maaslin2}} for details and allowed values. Default to 
-#' \code{"LOG"} (log transformation).
+#' \code{"AST"} (arcsine square root transformation).
 #' }
 #' \item{analysis_method}{
 #' character. \code{analysis_method} parameter for Maaslin2. See 

--- a/man/lm_meta.Rd
+++ b/man/lm_meta.Rd
@@ -4,8 +4,15 @@
 \alias{lm_meta}
 \title{Covariate adjusted meta-analytical differential abundance testing}
 \usage{
-lm_meta(feature_abd, batch, exposure, covariates = NULL,
-  covariates_random = NULL, data, control)
+lm_meta(
+  feature_abd,
+  batch,
+  exposure,
+  covariates = NULL,
+  covariates_random = NULL,
+  data,
+  control
+)
 }
 \arguments{
 \item{feature_abd}{feature-by-sample matrix of abundances (proportions or
@@ -75,7 +82,7 @@ character. \code{normalization} parameter for Maaslin2. See
 \item{transform}{
 character. \code{transform} parameter for Maaslin2. See 
 \code{\link[Maaslin2]{Maaslin2}} for details and allowed values. Default to 
-\code{"LOG"} (log transformation).
+\code{"AST"} (arcsine square root transformation).
 }
 \item{analysis_method}{
 character. \code{analysis_method} parameter for Maaslin2. See 


### PR DESCRIPTION
Hi,
While working with mmuphin I've noticed a couple small issues: 1. the documentation lists the default maaslin transform as LOG but it is set to be AST here (unlike in the maaslin package) 2. the names, especially those of features are frequently shortened to the point of not being able to read them.  I've made some changes to address these, let me know if this works, thanks!